### PR TITLE
Hide 'newUser' text when registration form is hidden

### DIFF
--- a/web/js/methods/Users/login.js
+++ b/web/js/methods/Users/login.js
@@ -646,7 +646,7 @@ Q.exports(function (Users, priv) {
 						);
 				}).attr('tabindex', 1002);
 				if (Q.text.Users.login.newUser) {
-					$p.append($('<div />').html(Q.text.Users.login.newUser));
+					$p.append($('<div class="Users_login_newUser" />').html(Q.text.Users.login.newUser));
 				}
 				$p.prependTo(form);
 				return form;
@@ -668,7 +668,7 @@ Q.exports(function (Users, priv) {
 				} else {
 					if (localStorage.getItem(priv._register_localStorageKey)
 					&& !Users.login.options.dontDiscourageMultipleAccounts) {
-						$('.Users_login_fullname_block, .Streams_login_fullname_block, .Streams_login_get_started', step2).hide();
+						$('.Users_login_fullname_block, .Streams_login_fullname_block, .Streams_login_get_started, .Users_login_newUser', step2).hide();
 					}
 					step2.slideDown('fast', function () {
 						$dc.scrollTop($dc[0].scrollHeight - $dc[0].clientHeight);


### PR DESCRIPTION
## Summary
- When the multiple-account discouragement feature hides the registration form fields, the "or create a new account below" text remained visible, creating a dead-end message referencing content that doesn't exist
- Added a `Users_login_newUser` class to the newUser div so it can be targeted
- Included `.Users_login_newUser` in the selector that hides form elements when `localStorage` has the register key and `dontDiscourageMultipleAccounts` is not set

## Test plan
- [ ] Enter an email that was previously used to register (triggers `emailExists` flow)
- [ ] Verify the "or create a new account below" text is hidden along with the registration form fields
- [ ] Verify the "Did you try to register..." and resend button still appear correctly
- [ ] With `dontDiscourageMultipleAccounts` option set, verify both the text and form fields appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)