### PR TITLE
Fix Users.signature silently dropping callback on insecure contexts

### DIFF
--- a/web/js/Users.js
+++ b/web/js/Users.js
@@ -555,6 +555,7 @@
 	 */
 	Users.signature = function (payload, callback, options) {
 		if (!crypto || !crypto.subtle) {
+			Q.handle(callback, null, ["Users.signature: insecure context, crypto.subtle unavailable"]);
 			return false;
 		}
 		var fieldNames = options && options.fieldNames;


### PR DESCRIPTION
## Summary

`Users.signature()` returns `false` without ever invoking the callback when `crypto.subtle` is undefined (insecure HTTP context). Any caller waiting on the callback hangs forever — no error, no completion, no XHR.

This breaks the entire `Q.req` signing flow over HTTP: the Users plugin's `beforeRequest` handler calls `Users.sign()` → `Users.signature()` → silent stall. Requests for any URL in `Users.requireLogin` (e.g. `Communities/me`) get stuck in `Q.loadUrl.loading` and never complete.

Fix is one line: invoke the callback with an explanatory error string before returning, matching the existing pattern at line 575 (`return Q.handle(callback, null, ["Users.signature: key not found"])`). Return value is preserved for any caller that checks it.

## Test plan

- [ ] Load any app over HTTP that includes a URL in `Users.requireLogin` (e.g. `Communities/me`)
- [ ] Click a nav element that triggers `Q.req` for that URL — verify the request completes (or fails with the new error string in the callback) instead of hanging
- [ ] Load the same app over HTTPS — verify signing still works as before (callback fires with signature, not the new error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)