### PR TITLE
Add Users_Label::hasLabel() convenience method

### DIFF
--- a/classes/Users/Label.php
+++ b/classes/Users/Label.php
@@ -283,6 +283,30 @@ class Users_Label extends Base_Users_Label
 	}
 
 	/**
+	 * Check whether a user holds one or more labels relative to a publisher.
+	 * Thin convenience wrapper over Users::roles for the common yes/no case.
+	 * @method hasLabel
+	 * @static
+	 * @param {string|array|Db_Expression} $label
+	 *   The label (or labels) to check for. Accepts the same forms as the
+	 *   $filter argument of Users::roles, so an array means "holds any of these".
+	 * @param {string|null} [$userId=null]
+	 *   The user whose label is being checked. Defaults to the logged-in user.
+	 * @param {string|null} [$publisherId=null]
+	 *   The publisher relative to whom to check. Defaults to Users::currentCommunityId().
+	 * @return {boolean} True if the user holds at least one matching label.
+	 */
+	static function hasLabel($label, $userId = null, $publisherId = null)
+	{
+		if (!isset($userId)) {
+			$user = Users::loggedInUser(true);
+			$userId = $user->id;
+		}
+		$roles = Users::roles($publisherId, $label, array(), $userId);
+		return !empty($roles);
+	}
+
+	/**
 	 * Whether $label_1 can grant $label_2
 	 * @method canGrantLabel
 	 * @param {string} $label_1 - Label doing the granting


### PR DESCRIPTION
## Summary

Adds a `Users_Label::hasLabel()` helper so code can check label membership without spelling out the `!empty(Users::roles(...))` idiom every time.

## Motivation

The current canonical way to check "does this user have label X in this community?" is:

```php
!empty(Users::roles($publisherId, $label, array(), $userId))
```

This shows up repeatedly in handlers that gate behavior on role membership (admin pages, moderator tools, role-scoped UI, etc.). It's:

- verbose for a yes/no question
- easy to get wrong (forgetting `!empty` flips the boolean)
- less discoverable than a named helper next to `addLabel` / `removeLabel` / `canGrantLabel` / `canRevokeLabel`, which already live on `Users_Label`

## Change

A single new static method on `Users_Label`. Thin wrapper over `Users::roles` — no new queries, no behavior change to existing code. Signature mirrors `removeLabel`: `(label, userId = null, publisherId = null)`.

## Backwards compatibility

Purely additive. No existing callers affected. No schema change.

## Notes

- Placed on `Users_Label` rather than `Users_User` to match the existing static-helper pattern (`addLabel`, `removeLabel`). Happy to add an instance-method alias on `Users_User` if preferred.
- Accepts the same `\$label` types as `Users::roles` (string / array / `Db_Range`), so `hasLabel(['Users/admins', 'Users/owners'], \$userId)` works as "holds any of these."

## Test plan

- [ ] Call `Users_Label::hasLabel('Users/admins')` for a user with and without the label; verify true/false
- [ ] Call with an array of labels; verify "any of" semantics
- [ ] Call with explicit `\$publisherId` for a non-default community
- [ ] Confirm logged-in-user default path works when `\$userId` omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)